### PR TITLE
Implement support for millisecond and microsecond times

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,12 @@ The aim of '''Time Manager plugin for QGIS''' is to provide comfortable browsing
 
 Time Manager filters your vector datasets (It only works for vector data!) and displays only features with timestamps in the user specified time frame. Timestamps have to be in one of the following formats:
 
+* YYYY-MM-DD HH:MM:SS.ssssss
 * YYYY-MM-DD HH:MM:SS
 * YYYY-MM-DD HH:MM
 * YYYY-MM-DD
+
+The list of supported time formats can augmented by adding to `supportedFormats` in `timelayer.py`
 
 The biggest tested dataset was a Spatialite table with indexed timestamps containing approximately 400,000 points, covering a time span of 24 hours. Stepping through the data for example in 1-hour-sized steps works without problems.
 

--- a/addLayer.ui
+++ b/addLayer.ui
@@ -54,29 +54,13 @@
       </widget>
      </item>
      <item row="3" column="0">
-      <widget class="QLabel" name="label_5">
-       <property name="text">
-        <string>Time Format:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <widget class="QComboBox" name="comboBoxTimeFormat">
-       <item>
-        <property name="text">
-         <string>%Y-%m-%d %H:%M:%S</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item row="4" column="0">
       <widget class="QLabel" name="label_6">
        <property name="text">
         <string>Offset (in sec):</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
+     <item row="3" column="1">
       <widget class="QSpinBox" name="spinBoxOffset">
        <property name="minimum">
         <number>-1000000000</number>
@@ -86,7 +70,7 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="2">
+     <item row="3" column="2">
       <widget class="QLabel" name="label_7">
        <property name="text">
         <string>(optional)</string>

--- a/dockwidget2.ui
+++ b/dockwidget2.ui
@@ -122,7 +122,7 @@
       <item>
        <widget class="QDateTimeEdit" name="dateTimeEditCurrentTime">
         <property name="displayFormat">
-         <string>yyyy-MM-dd HH:mm:ss</string>
+         <string>yyyy-MM-dd HH:mm:ss.zzz</string>
         </property>
        </widget>
       </item>

--- a/timemanagercontrol.py
+++ b/timemanagercontrol.py
@@ -209,7 +209,7 @@ class TimeManagerControl(QObject):
         original = timePosition
         if type(timePosition) == QDateTime:
             # convert QDateTime to datetime :S
-            timePosition = datetime.strptime( str(timePosition.toString('yyyy-MM-dd hh:mm:ss')) ,"%Y-%m-%d %H:%M:%S")
+            timePosition = datetime.strptime( str(timePosition.toString('yyyy-MM-dd hh:mm:ss.zzz')) ,"%Y-%m-%d %H:%M:%S.%f")
         elif type(timePosition) == int or type(timePosition) == float:
             timePosition = datetime.fromtimestamp(timePosition)
         if timePosition == self.currentMapTimePosition:

--- a/timemanagerguicontrol.py
+++ b/timemanagerguicontrol.py
@@ -36,10 +36,6 @@ class TimeManagerGuiControl(QObject):
         self.dock = uic.loadUi( os.path.join( path, "dockwidget2.ui" ) )
         self.iface.addDockWidget( Qt.BottomDockWidgetArea, self.dock )
         
-        # remove micro and milliseconds until supported
-        self.dock.comboBoxTimeExtent.removeItem(0) # microseconds
-        self.dock.comboBoxTimeExtent.removeItem(0) # milliseconds    
-        
         self.dock.pushButtonExportVideo.setEnabled(False) # only enabled if there are managed layers
         self.dock.comboBoxTimeExtent.setCurrentIndex(3) # should be 'days'
         
@@ -232,10 +228,6 @@ class TimeManagerGuiControl(QObject):
         # get attributes of the first layer for gui initialization
         self.getLayerAttributes(0)
 
-        # add additional supported time formats
-        supportedFormats=["%Y-%m-%d %H:%M","%Y-%m-%d"] # additional formats, the only default is %Y-%m-%d %H:%M:%S
-        self.addLayerDialog.comboBoxTimeFormat.addItems(supportedFormats)
-
         self.addLayerDialog.show()
 
         # establish connections
@@ -279,7 +271,7 @@ class TimeManagerGuiControl(QObject):
         endTime = self.addLayerDialog.comboBoxEnd.currentText()
         checkState = Qt.Checked
         layerId = self.layerIds[self.addLayerDialog.comboBoxLayers.currentIndex()]
-        timeFormat = self.addLayerDialog.comboBoxTimeFormat.currentText()
+        timeFormat = "%Y-%m-%d %H:%M:%S" # default
         offset = self.addLayerDialog.spinBoxOffset.value()
 
         self.addRowToOptionsTable(layerName,startTime,endTime,checkState,layerId,timeFormat,offset)
@@ -322,8 +314,8 @@ class TimeManagerGuiControl(QObject):
     def updateTimeExtents(self,timeExtents):
         """update time extents showing in labels and represented by horizontalTimeSlider"""
         if timeExtents != (None,None):
-            self.dock.labelStartTime.setText(str(timeExtents[0]))
-            self.dock.labelEndTime.setText(str(timeExtents[1]))
+            self.dock.labelStartTime.setText(str(timeExtents[0])[0:23])
+            self.dock.labelEndTime.setText(str(timeExtents[1])[0:23])
             self.dock.horizontalTimeSlider.setMinimum(mktime(timeExtents[0].timetuple())) 
             self.dock.horizontalTimeSlider.setMaximum(mktime(timeExtents[1].timetuple())) 
         else: # set to default values
@@ -382,7 +374,7 @@ class TimeManagerGuiControl(QObject):
             return
             
         self.font = QFont("Arial")         
-        self.labelString = str(self.dock.dateTimeEditCurrentTime.dateTime().toString("yyyy-MM-dd hh:mm:ss"))
+        self.labelString = str(self.dock.dateTimeEditCurrentTime.dateTime().toString("yyyy-MM-dd hh:mm:ss.zzz"))
         self.placementIndex = 3
         
         fm = QFontMetrics(self.font, painter.device())


### PR DESCRIPTION
This also deduces the time format rather than specifying it.  Time parsing
tries all the supported formats and saves the one that works to minimize
the try/except exception handling overhead.  The nice thing about this
is it makes it unnecessary to specify the time format when configuring
the TimeManager settings.

The current time setting in the project file gets truncated to the
previous second mark.  This is slightly annoying, but not annoying enough
for yours truly to fix.

Signed-off-by: Gerald Van Baren gvb@unssw.com
