### PR TITLE
fix for #14756, in which the feature count in the legend is not updated (#163 in Time Manager)

### DIFF
--- a/timemanagercontrol.py
+++ b/timemanagercontrol.py
@@ -224,8 +224,8 @@ class TimeManagerControl(QObject):
         """
         root = QgsProject.instance().layerTreeRoot()
         model = self.iface.layerTreeView().model()
-        for l in self.getTimeLayerManager().getManagedLayers():
-            model.refreshLayerLegend(root.findLayer(l.id()))
+        for l in self.getTimeLayerManager().getActiveVectors():
+            model.refreshLayerLegend(root.findLayer(l.getLayer().id()))
 
     def disableAnimationExport(self):
         """disable the animation export button"""

--- a/timemanagercontrol.py
+++ b/timemanagercontrol.py
@@ -210,10 +210,22 @@ class TimeManagerControl(QObject):
             self.guiControl.repaintJoined()
             self.guiControl.repaintVectors()
             self.guiControl.refreshMapCanvas()
+            self.updateLegendCount()
         except Exception, e:
             error(e)
         finally:
             self.setPropagateGuiChanges(True)
+
+    def updateLegendCount(self):
+        """
+        This method is actually a hack/fix for http://hub.qgis.org/issues/14756.
+        Untill this is fixed via some signal/action in the legend(tree), below is needed.
+        :return:
+        """
+        root = QgsProject.instance().layerTreeRoot()
+        model = self.iface.layerTreeView().model()
+        for l in self.getTimeLayerManager().getManagedLayers():
+            model.refreshLayerLegend(root.findLayer(l.id()))
 
     def disableAnimationExport(self):
         """disable the animation export button"""


### PR DESCRIPTION
This fixes the feature count (if shown) in legend.

See also this note from Martin: http://hub.qgis.org/issues/15844#note-8

It seems we are responsible ourself for this. So this is a way to update the legend (or actually the counting numbers there) upon every step you make in time.

To test, see: http://hub.qgis.org/issues/14756

I was not sure to put it here or in timemanagerguicontrol.  But because it actually needs the layers and references the legend outside of the plugin I decided to put it in the control itself.

I know get ALL manager layers, but I think only the vector ones are affected, but because I'm not aware of legend-things in a raster layer which maybe also had to be updated I update the legends of ALL managed layers.

What do you think?