### PR TITLE
Don't duplicate original subset string when removing time restriction

### DIFF
--- a/timevectorlayer.py
+++ b/timevectorlayer.py
@@ -273,7 +273,8 @@ class TimeVectorLayer(TimeLayer):
 
     def deleteTimeRestriction(self):
         """Restore original subset"""
-        self.setSubsetString(self.originalSubsetString)
+        success = self.layer.setSubsetString(self.originalSubsetString)
+        self.currSubsetString = self.originalSubsetString
 
     def hasTimeRestriction(self):
         """returns true if current layer.subsetString is not equal to originalSubsetString"""


### PR DESCRIPTION
The original subset string was stored locally and re-affected when the
time restriction was removed. Unfortunately the code used to set back
that original subset string was the same as the one used to set the
time restriction (`setSubsetString()`) and thus re-appended to itself.

This lead to huge duplicated SQL query that slowed down everything on
big data set (1 millions features).

Sorry I don't have the knowledge, nor the resources, to cover that with unit tests. Please feel free to either reject this PR as is, or contribute tests.