### PR TITLE
Fix #283 Actually remove the gui from QGIS

### DIFF
--- a/timemanagercontrol.py
+++ b/timemanagercontrol.py
@@ -69,7 +69,7 @@ class TimeManagerControl(QObject):
         self.getTimeLayerManager().deactivateTimeManagement()
         self.iface.unregisterMainWindowAction(self.actionShowSettings)
         self.guiControl.unload()
-
+        del self.guiControl # actually remove the gui panel
         self.iface.projectRead.disconnect(self.readSettings)
         self.iface.newProjectCreated.disconnect(self.restoreDefaults)
         self.iface.newProjectCreated.disconnect(self.disableAnimationExport)


### PR DESCRIPTION
This seems to fix that when you reload the plugin (for development)
using the 'Reload Plugin'-plugin you ended up with several
Time Manager gui panels in QGIS.