### PR TITLE
Guess wmst timeframes

### DIFF
--- a/layers/timelayermanager.py
+++ b/layers/timelayermanager.py
@@ -84,27 +84,34 @@ class TimeLayerManager(QObject):
         self.timeLayerList = []
 
     def timeFrame(self):
-        """returns the current time frame as datetime.timedelta
-        or compatible dateutil.relativedelta.relativedelta object"""
+        """Returns the current time frame as datetime.timedelta
+        or compatible dateutil.relativedelta.relativedelta object.
+        But when self.timeFrameSize is 0 (that is not working with frames but with
+        moments (eg possible in some wms-t services) return the timeframe of
+        1 (one timeFrameType). That makes it possible to set the timeFrameSize
+        to zero but still go over the timerange in steps of 1 timeFrameType."""
+        timeFrameSize = self.timeFrameSize
+        if self.timeFrameSize == 0:
+            timeFrameSize = 1  # so we can still step in steps of 'timeFrameType'
         if self.timeFrameType == 'years':
-            return relativedelta(years=self.timeFrameSize)  # years are not supported by timedelta
+            return relativedelta(years=timeFrameSize)  # years are not supported by timedelta
         elif self.timeFrameType == 'months':
             return relativedelta(
                 months=self.timeFrameSize)  # months are not supported by timedelta
         elif self.timeFrameType == 'weeks':
-            return timedelta(weeks=self.timeFrameSize)
+            return timedelta(weeks=timeFrameSize)
         elif self.timeFrameType == 'days':
-            return timedelta(days=self.timeFrameSize)
+            return timedelta(days=timeFrameSize)
         elif self.timeFrameType == 'hours':
-            return timedelta(hours=self.timeFrameSize)
+            return timedelta(hours=timeFrameSize)
         elif self.timeFrameType == 'minutes':
-            return timedelta(minutes=self.timeFrameSize)
+            return timedelta(minutes=timeFrameSize)
         elif self.timeFrameType == 'seconds':
-            return timedelta(seconds=self.timeFrameSize)
+            return timedelta(seconds=timeFrameSize)
         elif self.timeFrameType == 'milliseconds':
-            return timedelta(milliseconds=self.timeFrameSize)
+            return timedelta(milliseconds=timeFrameSize)
         elif self.timeFrameType == 'microseconds':
-            return timedelta(microseconds=self.timeFrameSize)
+            return timedelta(microseconds=timeFrameSize)
 
     @log_exceptions
     def refreshTimeRestrictions(self):
@@ -113,7 +120,10 @@ class TimeLayerManager(QObject):
             return
         if self.isEnabled():
             for timeLayer in self.getTimeLayerList():
-                timeLayer.setTimeRestriction(self.getCurrentTimePosition(), self.timeFrame())
+                if self.timeFrameSize == 0:
+                    timeLayer.setTimeRestriction(self.getCurrentTimePosition(),  timedelta(0))
+                else:
+                    timeLayer.setTimeRestriction(self.getCurrentTimePosition(), self.timeFrame())
         else:
             for timeLayer in self.getTimeLayerList():
                 if not timeLayer.hasTimeRestriction():

--- a/raster/wmstlayer.py
+++ b/raster/wmstlayer.py
@@ -94,7 +94,8 @@ class WMSTRasterLayer(TimeRasterLayer):
 
         # mmm, version parameter CAN be part of the url, and we get a version problem then
         # so let's default to 1.3.0 version if NOT in url
-        if 'VERSION' in self.wmsUrl.upper():
+        # adding %3D ( '='-sign ) to better filter url's with 'map' in it
+        if 'VERSION%3D' in self.wmsUrl.upper() or 'MAP%3D' in self.wmsUrl.upper():
             # use the version string from the url itself...
             # probably the url is urlencoded/quoted like: 'http://ies-ows.jrc.ec.europa.eu/effis?version%3D1.3.0'
             # so unquote it first
@@ -177,7 +178,7 @@ class WMSTRasterLayer(TimeRasterLayer):
                 # concatting a & behind ? is messing up QGIS wms parseUri: do NOT add anything behind it
                 return ""
             else:
-                return "%26" # equals &
+                return "%26"  # equals &
         else:
             return "?"
 

--- a/raster/wmstlayer.py
+++ b/raster/wmstlayer.py
@@ -8,7 +8,6 @@ from timemanager.utils import time_util
 from timemanager.layers.timerasterlayer import TimeRasterLayer
 from timemanager.layers.timelayer import TimeLayer, NotATimeAttributeError
 
-
 class WMSTRasterLayer(TimeRasterLayer):
     IGNORE_PREFIX = "IgnoreGetFeatureInfoUrl=1&IgnoreGetMapUrl=1&"
 
@@ -17,26 +16,113 @@ class WMSTRasterLayer(TimeRasterLayer):
 
         self.fromTimeAttribute = settings.startTimeAttribute
         self.toTimeAttribute = settings.endTimeAttribute
-        self.timeFormat = self.determine_format(settings.startTimeAttribute, settings.timeFormat)
         self.offset = int(settings.offset)
+        # TODO: better name this dataSourceUri ?
         self.originalUri = self.layer.dataProvider().dataSourceUri()
+
+        # try to get the timeExtents from what user put into gui (difficult!)
         try:
             self.getTimeExtents()
+            self.timeFormat = self.determine_format(
+                settings.startTimeAttribute, settings.timeFormat)
+            return
+        except Exception as e:
+            pass
+
+        # if above failed, try to retrieve the capabilities from the service
+        self.wmsUrl = ''
+        # contextualWMSLegend=0 & crs=EPSG:3857 & dpiMode=7 & featureCount=10 & format=image/png & layers=layername & styles & url=http://example.com/geoserver/wms
+        for key_val in self.originalUri.split('&'):
+            kv = key_val.split('=')
+            if len(kv) == 2 and kv[0].lower() == 'layers':
+                self.layerName = kv[1]
+            elif len(kv) == 2 and kv[0].lower() == 'url':
+                self.wmsUrl = kv[1]
+        try:
+            if self._get_time_extents_from_capabilities():
+                # succeeded in reading new from/to, save them in settings
+                settings.startTimeAttribute = self.fromTimeAttribute
+                settings.endTimeAttribute = self.toTimeAttribute
+                self.timeFormat = self.determine_format(
+                    self.fromTimeAttribute, settings.timeFormat)
         except NotATimeAttributeError as e:
             raise InvalidTimeLayerError(str(e))
 
-    def _get_wmts_layer_name():
-        return self.layer.subLayers(0)
+    def _get_time_extents_from_capabilities(self):
 
-    def _get_time_extents_from_uri(self):
-        # TODO get url from original uri
-        url = "http://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0r-t.cgi?&SERVICE=WMS&REQUEST=GetCapabilities"
-        # TODO get extents from the xml somehow
+        # A LOT OF different notations
+
+        # http://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0r-t.cgi?&service=WMS&version=1.3.0&request=getcapabilities
+        # <Dimension name="time" units="ISO8601" default="2006-06-23T03:10:00Z" nearestValue="0">1995-01-01/2019-12-31/PT5M</Dimension>
+        # # http://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0r-t.cgi?&service=WMS&version=1.1.1&request=getcapabilities
+        # <Dimension name="time" units="ISO8601"/><Extent name="time" default="2006-06-23T03:10:00Z" nearestValue="0">1995-01-01/2019-12-31/PT5M</Extent>
+
+        # http://geoservices.knmi.nl/cgi-bin/RADNL_OPER_R___25PCPRR_L3.cgi?service=wms&version=1.3.0&request=getcapabilities
+        # <Dimension name="time" units="ISO8601" default="2019-03-24T15:45:00Z" multipleValues="1" nearestValue="0" current="1">2012-01-01T00:00:00Z/2019-03-24T15:45:00Z/PT5M</Dimension>
+        # http://geoservices.knmi.nl/cgi-bin/RADNL_OPER_R___25PCPRR_L3.cgi?service=wms&version=1.1.1&request=getcapabilities
+        # <Dimension name="time" units="ISO8601"/><Extent name="time" default="2019-03-24T15:45:00Z" multipleValues="1" nearestValue="0">2012-01-01T00:00:00Z/2019-03-24T15:45:00Z/PT5M</Extent>
+
+        # geoserver 1.3.0 - http://localhost:8080/geoserver/wms?version=1.3.0&request=getCapabilities
+        # Interval and Resolution
+        # <Dimension name="time" default="current" units="ISO8601">2018-09-25T13:10:00.000Z/2018-09-26T01:00:00.000Z/PT10M</Dimension>
+        # Continues Interval:
+        # <Dimension name="time" default="2018-09-26T01:00:00Z" units="ISO8601">2018-09-25T13:10:00.000Z/2018-09-26T01:00:00.000Z/PT1S</Dimension>
+        # List
+        # <Dimension name="time" default="2018-09-26T01:00:00Z" units="ISO8601">2018-09-25T13:10:00.000Z,2018-09-25T13:20:00.000Z,2018-09-25T13:30:00.000Z,2018-09-25T13:40:00.000Z,2018-09-25T13:50:00.000Z,2018-09-25T14:00:00.000Z,2018-09-25T14:10:00.000Z,2018-09-25T14:20:00.000Z,2018-09-25T14:30:00.000Z,2018-09-25T14:40:00.000Z,2018-09-25T14:50:00.000Z,2018-09-25T15:00:00.000Z,2018-09-25T15:10:00.000Z,2018-09-25T15:20:00.000Z,2018-09-25T15:30:00.000Z,2018-09-25T15:40:00.000Z,2018-09-25T15:50:00.000Z,2018-09-25T16:00:00.000Z,2018-09-25T16:10:00.000Z,2018-09-25T16:20:00.000Z,2018-09-25T16:30:00.000Z,2018-09-25T16:40:00.000Z,2018-09-25T16:50:00.000Z,2018-09-25T17:00:00.000Z,2018-09-25T17:10:00.000Z,2018-09-25T17:20:00.000Z,2018-09-25T17:30:00.000Z,2018-09-25T17:40:00.000Z,2018-09-25T17:50:00.000Z,2018-09-25T18:00:00.000Z,2018-09-25T18:10:00.000Z,2018-09-25T18:20:00.000Z,2018-09-25T18:30:00.000Z,2018-09-25T18:40:00.000Z,2018-09-25T18:50:00.000Z,2018-09-25T19:00:00.000Z,2018-09-25T19:10:00.000Z,2018-09-25T19:20:00.000Z,2018-09-25T19:30:00.000Z,2018-09-25T19:40:00.000Z,2018-09-25T19:50:00.000Z,2018-09-25T20:00:00.000Z,2018-09-25T20:10:00.000Z,2018-09-25T20:20:00.000Z,2018-09-25T20:30:00.000Z,2018-09-25T20:40:00.000Z,2018-09-25T20:50:00.000Z,2018-09-25T21:00:00.000Z,2018-09-25T21:10:00.000Z,2018-09-25T21:20:00.000Z,2018-09-25T21:30:00.000Z,2018-09-25T21:40:00.000Z,2018-09-25T21:50:00.000Z,2018-09-25T22:00:00.000Z,2018-09-25T22:10:00.000Z,2018-09-25T22:20:00.000Z,2018-09-25T22:30:00.000Z,2018-09-25T22:40:00.000Z,2018-09-25T22:50:00.000Z,2018-09-25T23:00:00.000Z,2018-09-25T23:10:00.000Z,2018-09-25T23:20:00.000Z,2018-09-25T23:30:00.000Z,2018-09-25T23:40:00.000Z,2018-09-25T23:50:00.000Z,2018-09-26T00:00:00.000Z,2018-09-26T00:10:00.000Z,2018-09-26T00:20:00.000Z,2018-09-26T00:30:00.000Z,2018-09-26T00:40:00.000Z,2018-09-26T00:50:00.000Z,2018-09-26T01:00:00.000Z</Dimension>
+        #
+        # geoserver 1.1.1 - http://localhost:8080/geoserver/wms?version=1.1.1&request=getCapabilities
+        # Interval and Resolution
+        # <Dimension name="time" units="ISO8601"/><Extent name="time" default="current">2018-09-25T13:10:00.000Z/2018-09-26T01:00:00.000Z/PT10M</Extent>
+        # Continues Interval:
+        # <Dimension name="time" units="ISO8601"/><Extent name="time" default="2018-09-26T01:00:00Z">2018-09-25T13:10:00.000Z/2018-09-26T01:00:00.000Z/PT1S</Extent>
+        # List
+        # <Dimension name="time" units="ISO8601"/><Extent name="time" default="2018-09-26T01:00:00Z">2018-09-25T13:10:00.000Z,2018-09-25T13:20:00.000Z,2018-09-25T13:30:00.000Z,2018-09-25T13:40:00.000Z,2018-09-25T13:50:00.000Z,2018-09-25T14:00:00.000Z,2018-09-25T14:10:00.000Z,2018-09-25T14:20:00.000Z,2018-09-25T14:30:00.000Z,2018-09-25T14:40:00.000Z,2018-09-25T14:50:00.000Z,2018-09-25T15:00:00.000Z,2018-09-25T15:10:00.000Z,2018-09-25T15:20:00.000Z,2018-09-25T15:30:00.000Z,2018-09-25T15:40:00.000Z,2018-09-25T15:50:00.000Z,2018-09-25T16:00:00.000Z,2018-09-25T16:10:00.000Z,2018-09-25T16:20:00.000Z,2018-09-25T16:30:00.000Z,2018-09-25T16:40:00.000Z,2018-09-25T16:50:00.000Z,2018-09-25T17:00:00.000Z,2018-09-25T17:10:00.000Z,2018-09-25T17:20:00.000Z,2018-09-25T17:30:00.000Z,2018-09-25T17:40:00.000Z,2018-09-25T17:50:00.000Z,2018-09-25T18:00:00.000Z,2018-09-25T18:10:00.000Z,2018-09-25T18:20:00.000Z,2018-09-25T18:30:00.000Z,2018-09-25T18:40:00.000Z,2018-09-25T18:50:00.000Z,2018-09-25T19:00:00.000Z,2018-09-25T19:10:00.000Z,2018-09-25T19:20:00.000Z,2018-09-25T19:30:00.000Z,2018-09-25T19:40:00.000Z,2018-09-25T19:50:00.000Z,2018-09-25T20:00:00.000Z,2018-09-25T20:10:00.000Z,2018-09-25T20:20:00.000Z,2018-09-25T20:30:00.000Z,2018-09-25T20:40:00.000Z,2018-09-25T20:50:00.000Z,2018-09-25T21:00:00.000Z,2018-09-25T21:10:00.000Z,2018-09-25T21:20:00.000Z,2018-09-25T21:30:00.000Z,2018-09-25T21:40:00.000Z,2018-09-25T21:50:00.000Z,2018-09-25T22:00:00.000Z,2018-09-25T22:10:00.000Z,2018-09-25T22:20:00.000Z,2018-09-25T22:30:00.000Z,2018-09-25T22:40:00.000Z,2018-09-25T22:50:00.000Z,2018-09-25T23:00:00.000Z,2018-09-25T23:10:00.000Z,2018-09-25T23:20:00.000Z,2018-09-25T23:30:00.000Z,2018-09-25T23:40:00.000Z,2018-09-25T23:50:00.000Z,2018-09-26T00:00:00.000Z,2018-09-26T00:10:00.000Z,2018-09-26T00:20:00.000Z,2018-09-26T00:30:00.000Z,2018-09-26T00:40:00.000Z,2018-09-26T00:50:00.000Z,2018-09-26T01:00:00.000Z</Extent>
+
+
+        url = self.wmsUrl + self.addUrlMark() + 'service=wms&version=1.3.0&request=getCapabilities'
+        # TODO: remove urllib dependency, use QgsNetworkManager !
         import urllib.request, urllib.parse
-
+        import xml.etree.ElementTree as ET
         raw_xml = urllib.request.urlopen(url).read()
-        name = self._get_wmts_layer_name()
-        return None, None
+        root = ET.fromstring(raw_xml.decode("utf-8"))
+        #print(root.tag)
+        for lyr in root.iter('{http://www.opengis.net/wms}Layer'):
+            # print(lyr)
+            for name in lyr.findall('{http://www.opengis.net/wms}Name'):
+                # print(name.text)
+                if name.text == self.layerName:
+                    dimension = lyr.find(
+                        '{http://www.opengis.net/wms}Dimension')
+                    if dimension is not None:
+                        # TODO handle other notations
+                        dims = dimension.text
+                        # Geoserver 1.3.0 notation when 'Presentation' is set
+                        #  to 'Interval and resolution' or 'Continues Interval'
+                        # 2019-02-12T05:10:00.000Z/2019-02-12T17:00:00.000Z/PT10M
+                        if len(dims.split('/')) == 3:
+                            interval_start, interval_end, resolution = \
+                                dimension.text.split('/')
+                            # print(interval_start, interval_end, resolution)
+                        # Geoserver 1.3.0 notation when 'Presentation' is set to 'List'
+                        # 2018-09-25T13:10:00.000Z,2018-09-25T13:20:00.000Z,2018-09-25T13:30:00.000Z, ...
+                        elif len(dims.split(',')) > 2:
+                            interval_start = dims.split(',')[0]
+                            interval_end = dims.split(',')[-1]
+                            # print(interval_start, interval_end, resolution)
+                        elif (len(dims.split(',')) == 1 and len(dims.split('/')) == 1):
+                            # some services show dimension like
+                            interval_start = dims
+                            interval_end = dims
+                        else:
+                            # not yet implemented ?
+                            return False
+
+                        self.fromTimeAttribute = interval_start
+                        self.toTimeAttribute = interval_end
+                        # would be cool to be able to set or indicate a favoured timeFrameLength
+                        # maybe in messagebar?
+                        return True
+        return False
 
     def getTimeExtents(self):
         startTime, endTime = time_util.str_to_datetime(self.fromTimeAttribute, self.timeFormat), \
@@ -62,9 +148,17 @@ class WMSTRasterLayer(TimeRasterLayer):
             return
         startTime = timePosition + timedelta(seconds=self.offset)
         endTime = timePosition + timeFrame + timedelta(seconds=self.offset)
+        if timeFrame == timedelta(0):
+            # when timeFrame is set to 0 we can handle services which can serve
+            # momentarily timeslices not sure what is better:
+            # TIME=2019-03-01T10:00:00Z
+            # or a range of zero by giving the same time as start and end:
+            # TIME=2019-03-01T10:00:00Z/2019-03-01T10:00:00Z
+            endTime = startTime # hope all services can handle a time-range of zero
         timeString = "TIME={}/{}".format(
             time_util.datetime_to_str(startTime, self.timeFormat),
             time_util.datetime_to_str(endTime, self.timeFormat))
+
         dataUrl = self.IGNORE_PREFIX + self.originalUri + self.addUrlMark() + timeString
         #print "original URL: " + self.originalUri
         #print "final URL: " + dataUrl

--- a/timemanagerguicontrol.py
+++ b/timemanagerguicontrol.py
@@ -370,7 +370,7 @@ class TimeManagerGuiControl(QObject):
         self.signalTimeFrameType.emit(frameType)
 
     def currentTimeFrameSizeChanged(self, frameSize):
-        if frameSize < 1:  # time frame size = 0  is meaningless
+        if frameSize < 0:  # time frame size = 0 is used for wms-t layers
             self.dock.spinBoxTimeExtent.setValue(1)
             return
         self.signalTimeFrameSize.emit(frameSize)

--- a/utils/time_util.py
+++ b/utils/time_util.py
@@ -129,6 +129,7 @@ def generate_all_timezones(fmt):
 
 
 BASIC_SUPPORTED_FORMATS = [
+    "%Y-%m-%dT%H:%M:%S.%fZ",
     "%Y-%m-%d %H:%M:%S.%f",
     "%Y-%m-%d %H:%M:%S",
     "%Y-%m-%d %H:%M",


### PR DESCRIPTION
Having a Geoserver with WMS-t layers, adding a layer via TimeManager is really difficult.
Guessing the time formats etc etc is just hard (besides the most often used timeformat was not yet part of the predefined formats :-) ) 

So this commits use urllib to request the (version 1.3.0-) capabilities of the wms-t layer, tries to get the 'Dimension' node and then tries to interpret the value of it.

There are a lot of different ways to define those ranges, but most wms's use a notation like 
``2018-09-25T13:10:00.000Z/2018-09-26T01:00:00.000Z/PT10M``
being start/time/period

Unfortunately we cannot use the Period-definition yet, PT10M for example could be used to so set timeFrameSize 10 and timeFrameType to minutes...

Some public service to try:
Dutch rain-radar (epsg:28992):
``http://geoservices.knmi.nl/cgi-bin/RADNL_OPER_R___25PCPRR_L3.cgi``
Nasa (with SOME layers time enabled).
``https://neo.sci.gsfc.nasa.gov/wms/wms``

For the dutch service requesting a layer using TIME=start/end format returns a stack of images from start to end, so it's better to request it using TIME=moment or TIME=moment/moment
This is made possible to bring back(?) the zero sized timeframe. Defining a zero-timeframe the wms-t request will have TIME=moment/moment formats. 
To make it possible to step through time (eg using the forward/backward buttons) with a zero-timeFrameSize I look at the current timeFrameType dropdown. So having a timeFrameSize of 0 and a timeFrameType of day, you wil step day by day. When having a non-zero timeFrameSize old behaviour should not have been changed.

Not sure if I should make this a WIP (Work In Progress) or not.
Would be nice if people could test some of their services (it works for my own Geoserver and above services).

Another thing that would be nice, is to have more feedback when a user tries to add a layer, adding a wms-t layer will silently fail, without any suggestion what is wrong (timeformat or other)?
Should we make it possible to the MessageLog or to the MessageBar?

Then there is the 'problem' that I just used the start that was already there which used urllib, instead of the better QgsNetworkAccessManager...

I hope people have some services to test.
