### PR TITLE
Fix WMST with authentication

### DIFF
--- a/raster/wmstlayer.py
+++ b/raster/wmstlayer.py
@@ -3,6 +3,7 @@ standard_library.install_aliases()
 # -*- coding: utf-8 -*-
 
 from datetime import timedelta
+
 from timemanager.utils import time_util
 from timemanager.layers.timerasterlayer import TimeRasterLayer
 from timemanager.layers.timelayer import TimeLayer, NotATimeAttributeError
@@ -87,4 +88,3 @@ class WMSTRasterLayer(TimeRasterLayer):
         self.layer.dataProvider().reloadData()
         self.layer.triggerRepaint()
 
-        

--- a/raster/wmstlayer.py
+++ b/raster/wmstlayer.py
@@ -65,7 +65,15 @@ class WMSTRasterLayer(TimeRasterLayer):
         timeString = "TIME={}/{}".format(
             time_util.datetime_to_str(startTime, self.timeFormat),
             time_util.datetime_to_str(endTime, self.timeFormat))
-        dataUrl = self.IGNORE_PREFIX + self.originalUri + self.addUrlMark() + timeString
+
+        uriPos = self.originalUri.find("url=")
+        uriEnd = self.originalUri[uriPos:].find("&")
+        uriEnd = uriPos + uriEnd if uriEnd != -1 else len(self.originalUri)
+        replaceUri = self.originalUri[uriPos:uriEnd]
+        newUri = replaceUri + self.addUrlMark(replaceUri) + timeString
+        replacedOriginalUri = self.originalUri.replace(replaceUri, newUri)
+
+        dataUrl = self.IGNORE_PREFIX + replacedOriginalUri
         #print "original URL: " + self.originalUri
         #print "final URL: " + dataUrl
         self.layer.dataProvider().setDataSourceUri(dataUrl)

--- a/raster/wmstlayer.py
+++ b/raster/wmstlayer.py
@@ -76,8 +76,6 @@ class WMSTRasterLayer(TimeRasterLayer):
         dataUrl = self.IGNORE_PREFIX + replacedOriginalUri
         #print "original URL: " + self.originalUri
         #print "final URL: " + dataUrl
-        QgsMessageLog.logMessage("original URL: " + self.originalUri)
-        QgsMessageLog.logMessage("final URL: " + dataUrl)
         self.layer.dataProvider().setDataSourceUri(dataUrl)
         self.layer.dataProvider().reloadData()
 

--- a/raster/wmstlayer.py
+++ b/raster/wmstlayer.py
@@ -3,7 +3,7 @@ standard_library.install_aliases()
 # -*- coding: utf-8 -*-
 
 from datetime import timedelta
-
+from qgis.core import QgsMessageLog
 from timemanager.utils import time_util
 from timemanager.layers.timerasterlayer import TimeRasterLayer
 from timemanager.layers.timelayer import TimeLayer, NotATimeAttributeError
@@ -45,9 +45,9 @@ class WMSTRasterLayer(TimeRasterLayer):
         endTime += timedelta(seconds=self.offset)
         return (startTime, endTime)
 
-    def addUrlMark(self):
-        if "?" in self.originalUri:
-            if self.originalUri.endswith('?'):
+    def addUrlMark(self, uri):
+        if "?" in uri:
+            if uri.endswith('?'):
                 # concatting a & behind ? is messing up QGIS wms parseUri: do NOT add anything behind it
                 return ""
             else:
@@ -65,7 +65,7 @@ class WMSTRasterLayer(TimeRasterLayer):
         timeString = "TIME={}/{}".format(
             time_util.datetime_to_str(startTime, self.timeFormat),
             time_util.datetime_to_str(endTime, self.timeFormat))
-
+            
         uriPos = self.originalUri.find("url=")
         uriEnd = self.originalUri[uriPos:].find("&")
         uriEnd = uriPos + uriEnd if uriEnd != -1 else len(self.originalUri)
@@ -76,6 +76,8 @@ class WMSTRasterLayer(TimeRasterLayer):
         dataUrl = self.IGNORE_PREFIX + replacedOriginalUri
         #print "original URL: " + self.originalUri
         #print "final URL: " + dataUrl
+        QgsMessageLog.logMessage("original URL: " + self.originalUri)
+        QgsMessageLog.logMessage("final URL: " + dataUrl)
         self.layer.dataProvider().setDataSourceUri(dataUrl)
         self.layer.dataProvider().reloadData()
 
@@ -85,4 +87,3 @@ class WMSTRasterLayer(TimeRasterLayer):
         self.layer.dataProvider().setDataSourceUri(self.originalUri)
         self.layer.dataProvider().reloadData()
         self.layer.triggerRepaint()
-

--- a/raster/wmstlayer.py
+++ b/raster/wmstlayer.py
@@ -3,7 +3,6 @@ standard_library.install_aliases()
 # -*- coding: utf-8 -*-
 
 from datetime import timedelta
-from qgis.core import QgsMessageLog
 from timemanager.utils import time_util
 from timemanager.layers.timerasterlayer import TimeRasterLayer
 from timemanager.layers.timelayer import TimeLayer, NotATimeAttributeError
@@ -87,3 +86,5 @@ class WMSTRasterLayer(TimeRasterLayer):
         self.layer.dataProvider().setDataSourceUri(self.originalUri)
         self.layer.dataProvider().reloadData()
         self.layer.triggerRepaint()
+
+        


### PR DESCRIPTION
When you use a WMS service that requires authentication, QGIS adds to the originalUri as last parameter "username=john" after the "uri=" parameter.
As an example, it can look like this: ```...&uri=https://wms.example.org/wms&username=john```
Now the current timeString addition to that url results in ```...&uri=https://wms.example.org/wms&username=john?TIME=<time1>/<time2>``` which then is discarded by QGIS as it is not a valid url.
Instead, we want to have the following result in this case: ```...&uri=https://wms.example.org/wms?TIME=<time1>/<time2>&username=john``` which works. When having additional parameters in the uri, like ```...&uri=https://wms.example.org/wms?version=1.1.0&username=john```, then we obviously need to add via %26, as in ```...&uri=https://wms.example.org/wms?version=1.1.0%26TIME=<time1>/<time2>&username=john```

This fix allows all these use cases and also still works with uris that don't need authentication (means they end with ```...&uri=https://wms.example.org/wms?version=1.1.0``` or ```...&uri=https://wms.example.org/wms``` without username attribute.